### PR TITLE
Do not include unneeded files in XPI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL := /bin/bash
 VERSION := $(shell cat install.rdf|grep '<em:version>'|cut -d\> -f2|cut -d\< -f1)
 
 make-xpi:
-	zip -r ../torbirdy-$(VERSION).xpi * -x "/screenshots/*" -x "*/screenshots/*"
+	zip -r ../torbirdy-$(VERSION).xpi * -x "/screenshots/*" -x "*/screenshots/*"  -x "debian/*" -x "patches/*" -x TODO -x ChangeLog
 
 git-tag:
 	git tag -u 0xD81D840E -s $(VERSION)


### PR DESCRIPTION
Do not include debian, patches and other files in XPI. This commit will fix this.
