### PR TITLE
Fixed Makefile to (really) not include TODO/ChangeLog files. Added clean target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
 SHELL := /bin/bash
 VERSION := $(shell cat install.rdf|grep '<em:version>'|cut -d\> -f2|cut -d\< -f1)
 
+clean:
+	rm -f ../torbirdy-$(VERSION).xpi
+
 make-xpi:
-	zip -r ../torbirdy-$(VERSION).xpi * -x "/screenshots/*" -x "*/screenshots/*"  -x "debian/*" -x "patches/*" -x TODO -x ChangeLog
+	zip -r ../torbirdy-$(VERSION).xpi * -x "/screenshots/*" -x "*/screenshots/*"  -x "debian/*" -x "patches/*" -x "TODO" -x "ChangeLog"
 
 git-tag:
 	git tag -u 0xD81D840E -s $(VERSION)


### PR DESCRIPTION
- Added clean target.
- Make sure that we really not include TODO, ChangeLog in XPI. Previous patch had missing "" in fix.
