### PR TITLE
gpg.conf optimized for privacy

### DIFF
--- a/gpg.conf
+++ b/gpg.conf
@@ -1,0 +1,77 @@
+## gpg.conf optimized for privacy
+
+##################################################################
+## BEGIN some suggestions from TorBirdy setting extensions.enigmail.agentAdditionalParam
+
+## Don't disclose the version
+no-emit-version
+
+## Don't add additional comments (may leak language, etc)
+no-comments
+
+## Don't include keyids that may disclose the sender or any other non-obvious keyids
+throw-keyids
+
+## We want to force UTF-8 everywhere
+display-charset utf-8
+
+## Proxy settings
+keyserver-options http-proxy=socks5://TORIP:TORPORT
+
+keyserver hkp://2eghzlv2wwcq7u7y.onion
+
+## END some suggestions from TorBirdy TorBirdy setting extensions.enigmail.agentAdditionalParam
+##################################################################
+
+##################################################################
+## BEGIN Some suggestions from Debian http://keyring.debian.org/creating-key.html
+
+personal-digest-preferences SHA512
+cert-digest-algo SHA512
+default-preference-list SHA512 SHA384 SHA256 SHA224 AES256 AES192 AES CAST5 ZLIB BZIP2 ZIP Uncompressed
+
+## END Some suggestions from Debian http://keyring.debian.org/creating-key.html
+##################################################################
+
+##################################################################
+## BEGIN Some suggestions added from riseup https://we.riseup.net/riseuplabs+paow/openpgp-best-practices
+
+## When creating a key, individuals may designate a specific keyserver to use to pull their keys from.
+## The above option will disregard this designation and use the pool, which is useful because (1) it
+## prevents someone from designating an insecure method for pulling their key and (2) if the server
+## designated uses hkps, the refresh will fail because the ca-cert will not match, so the keys will
+## never be refreshed.
+keyserver-options no-honor-keyserver-url
+
+## when outputting certificates, view user IDs distinctly from keys:
+fixed-list-mode
+
+## long keyids are more collision-resistant than short keyids (it's trivial to make a key with any desired short keyid)
+keyid-format 0xlong
+
+## when multiple digests are supported by all recipients, choose the strongest one:
+## already defined above
+#personal-digest-preferences SHA512 SHA384 SHA256 SHA224
+
+## preferences chosen for new keys should prioritize stronger algorithms:
+## already defined above
+#default-preference-list SHA512 SHA384 SHA256 SHA224 AES256 AES192 AES CAST5 BZIP2 ZLIB ZIP Uncompressed
+
+## If you use a graphical environment (and even if you don't) you should be using an agent:
+## (similar arguments as https://www.debian-administration.org/users/dkg/weblog/64)
+use-agent
+
+## You should always know at a glance which User IDs gpg thinks are legitimately bound to the keys in your keyring:
+verify-options show-uid-validity
+list-options show-uid-validity
+
+## include an unambiguous indicator of which key made a signature:
+## (see http://thread.gmane.org/gmane.mail.notmuch.general/3721/focus=7234)
+sig-notation issuer-fpr@notations.openpgp.fifthhorseman.net=%g
+
+## when making an OpenPGP certification, use a stronger digest than the default SHA1:
+## already defined above
+#cert-digest-algo SHA256
+
+## END Some suggestions added from riseup https://we.riseup.net/riseuplabs+paow/openpgp-best-practices
+##################################################################


### PR DESCRIPTION
For anonymous e-mail, we now have Thunderbird + TorBirdy. But what are the recommended settings for gpg used in terminal?

The world needs a recommended gpg.conf in context of Tor. I've discussed this with @sukhbir by e-mail.

Feel free to add/remove any of my comments and/or change any settings.
