### PR TITLE
Disable `--throw-keyids' by default

### DIFF
--- a/gpg.conf
+++ b/gpg.conf
@@ -9,9 +9,6 @@ no-emit-version
 ## Don't add additional comments (may leak language, etc)
 no-comments
 
-## Don't include keyids that may disclose the sender or any other non-obvious keyids
-throw-keyids
-
 ## We want to force UTF-8 everywhere
 display-charset utf-8
 
@@ -74,4 +71,17 @@ sig-notation issuer-fpr@notations.openpgp.fifthhorseman.net=%g
 #cert-digest-algo SHA256
 
 ## END Some suggestions added from riseup https://we.riseup.net/riseuplabs+paow/openpgp-best-practices
+##################################################################
+
+##################################################################
+## BEGIN Some suggestions from TorBirdy opt-in's
+
+## Up to you whether you in comment it (remove the single # in front of
+## it) or not. Disabled by default, because it causes too much complaints and
+## confusion.
+
+## Don't include keyids that may disclose the sender or any other non-obvious keyids
+#throw-keyids
+
+## END Some suggestions from TorBirdy opt-in's
 ##################################################################


### PR DESCRIPTION
as per https://github.com/ioerror/torbirdy/commit/bdbcdac4c0415d5ea4e00bdb08be407b5ec1300f
