### PR TITLE
helo_argument IP should be encapsulated in []'s

### DIFF
--- a/components/torbirdy.js
+++ b/components/torbirdy.js
@@ -166,7 +166,7 @@ const TorBirdyPrefs = {
   */
 
   // Prevent hostname leaks.
-  "mail.smtpserver.default.hello_argument": "127.0.0.1",
+  "mail.smtpserver.default.hello_argument": "[127.0.0.1]",
   // Compose messages in plain text (by default).
   "mail.html_compose": false,
   "mail.identity.default.compose_html": false,


### PR DESCRIPTION
This is a patch proposed by Chris Knadle chris.knadle@coredump.us
to make torbirdy compliant with RFC 5821 §4.1.3.
Also see Debian bug:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=812115

Also look at which has a related issue:
https://trac.torproject.org/projects/tor/ticket/13006