### PR TITLE
Secure autoconfiguration

### DIFF
--- a/chrome/content/emailwizard.js
+++ b/chrome/content/emailwizard.js
@@ -124,12 +124,9 @@ if(!org.torbirdy.emailwizard) org.torbirdy.emailwizard = new function() {
   pub.onLoad = function() {
     if (disableWizard) {
       document.getElementById("torbirdy-protocol-box").collapsed = true;
-      document.getElementById("provisioner_button").disabled = false;
-      document.getElementById("provisioner_button").hidden = false;
-    } else {
-      document.getElementById("provisioner_button").disabled = true;
-      document.getElementById("provisioner_button").hidden = true;
     }
+    document.getElementById("provisioner_button").disabled = true;
+    document.getElementById("provisioner_button").hidden = true;
   };
 
   return pub;

--- a/chrome/content/emailwizard.js
+++ b/chrome/content/emailwizard.js
@@ -7,16 +7,7 @@ if(!org.torbirdy.emailwizard) org.torbirdy.emailwizard = new function() {
   var prefs = Cc["@mozilla.org/preferences-service;1"]
                 .getService(Ci.nsIPrefBranch);
 
-  // Check if we are running Tails. If yes, disable the manual account
-  // configuration wizard since Tails handles that on its own. See:
-  // https://tails.boum.org/todo/Return_of_Icedove__63__/#index6h2
-  // This is also disabled if "extensions.torbirdy.emailwizard" is true.
   var disableWizard = false;
-  if (prefs.prefHasUserValue("vendor.name")) {
-    if (prefs.getCharPref("vendor.name") === "Tails") {
-      disableWizard = true;
-    }
-  }
   if (prefs.getBoolPref("extensions.torbirdy.emailwizard")) {
     disableWizard = true;
   }

--- a/chrome/content/emailwizard.js
+++ b/chrome/content/emailwizard.js
@@ -6,10 +6,7 @@ if (!org.torbirdy) org.torbirdy = {};
 if(!org.torbirdy.emailwizard) org.torbirdy.emailwizard = new function() {
   var pub = {};
 
-  var disableWizard = false;
-  if (Preferences.get("extensions.torbirdy.emailwizard", false)) {
-    disableWizard = true;
-  }
+  var disableWizard = !Preferences.get("extensions.torbirdy.emailwizard", false);
 
   fixupTorbirdySettingsOnNewAccount = function(account) {
     var idkey = account.defaultIdentity.key;

--- a/chrome/content/emailwizard.js
+++ b/chrome/content/emailwizard.js
@@ -12,7 +12,7 @@ if(!org.torbirdy.emailwizard) org.torbirdy.emailwizard = new function() {
     disableWizard = true;
   }
 
-  pub.disableAutoWizard = function() {
+  pub.adjustAutoWizard = function() {
     if (!disableWizard) {
       var realname = document.getElementById("realname").value;
       var email = document.getElementById("email").value;
@@ -117,7 +117,7 @@ if(!org.torbirdy.emailwizard) org.torbirdy.emailwizard = new function() {
     if (keycode == 13) {
       if (document.getElementById("next_button").disabled === false) {
         if (!disableWizard) {
-          pub.disableAutoWizard();
+          pub.adjustAutoWizard();
         }
         else {
           gEmailConfigWizard.onNext();

--- a/chrome/content/emailwizard.js
+++ b/chrome/content/emailwizard.js
@@ -116,12 +116,7 @@ if(!org.torbirdy.emailwizard) org.torbirdy.emailwizard = new function() {
     var keycode = event.keyCode;
     if (keycode == 13) {
       if (document.getElementById("next_button").disabled === false) {
-        if (!disableWizard) {
-          pub.adjustAutoWizard();
-        }
-        else {
-          gEmailConfigWizard.onNext();
-        }
+        pub.adjustAutoWizard();
       }
     }
   };

--- a/chrome/content/emailwizard.js
+++ b/chrome/content/emailwizard.js
@@ -6,11 +6,8 @@ if (!org.torbirdy) org.torbirdy = {};
 if(!org.torbirdy.emailwizard) org.torbirdy.emailwizard = new function() {
   var pub = {};
 
-  var prefs = Cc["@mozilla.org/preferences-service;1"]
-                .getService(Ci.nsIPrefBranch);
-
   var disableWizard = false;
-  if (prefs.getBoolPref("extensions.torbirdy.emailwizard")) {
+  if (Preferences.get("extensions.torbirdy.emailwizard", false)) {
     disableWizard = true;
   }
 

--- a/chrome/content/emailwizard.js
+++ b/chrome/content/emailwizard.js
@@ -6,7 +6,10 @@ if (!org.torbirdy) org.torbirdy = {};
 if(!org.torbirdy.emailwizard) org.torbirdy.emailwizard = new function() {
   var pub = {};
 
-  var disableWizard = !Preferences.get("extensions.torbirdy.emailwizard", false);
+  var disableAutoConfiguration = false;
+  if (Preferences.get("extensions.torbirdy.emailwizard", false)) {
+    disableAutoConfiguration = true;
+  }
 
   fixupTorbirdySettingsOnNewAccount = function(account) {
     var idkey = account.defaultIdentity.key;
@@ -37,7 +40,7 @@ if(!org.torbirdy.emailwizard) org.torbirdy.emailwizard = new function() {
   }
 
   pub.adjustAutoWizard = function() {
-    if (!disableWizard) {
+    if (!disableAutoConfiguration) {
       var realname = document.getElementById("realname").value;
       var email = document.getElementById("email").value;
       var password = document.getElementById("password").value;
@@ -134,7 +137,7 @@ if(!org.torbirdy.emailwizard) org.torbirdy.emailwizard = new function() {
   };
 
   pub.onLoad = function() {
-    if (disableWizard) {
+    if (disableAutoConfiguration) {
       document.getElementById("torbirdy-protocol-box").collapsed = true;
     }
     document.getElementById("provisioner_button").disabled = true;

--- a/chrome/content/emailwizard.js
+++ b/chrome/content/emailwizard.js
@@ -81,10 +81,6 @@ if(!org.torbirdy.emailwizard) org.torbirdy.emailwizard = new function() {
       config.incoming.auth = 3;
       config.outgoing.auth = 3;
 
-      // Set default values to disable automatic email fetching.
-      config.incoming.loginAtStartup = false;
-      config.incoming.downloadOnBiff = false;
-
       // Default the outgoing SMTP port.
       config.outgoing.port = 465;
 

--- a/chrome/content/emailwizard.js
+++ b/chrome/content/emailwizard.js
@@ -1,3 +1,5 @@
+Components.utils.import("resource://gre/modules/Preferences.jsm");
+
 if (!org) var org = {};
 if (!org.torbirdy) org.torbirdy = {};
 
@@ -17,28 +19,26 @@ if(!org.torbirdy.emailwizard) org.torbirdy.emailwizard = new function() {
     var serverkey = account.incomingServer.key;
     var protocol = account.incomingServer.type;
 
+    var pref_spec = [
+        ['mail.server.%serverkey%.check_new_mail', false],
+        ['mail.server.%serverkey%.login_at_startup', false]
+    ];
+
     // Make sure that drafts are saved to Local Folders if it is an IMAP account.
     if (protocol === "imap") {
-      var draftFolder = 'mail.identity.%idkey%.draft_folder';
-      var draftFolderPref = draftFolder.replace("%idkey%", idkey);
-      prefs.setCharPref(draftFolderPref, "mailbox://nobody@Local%20Folders/Drafts");
+        pref_spec.push(['mail.identity.%idkey%.draft_folder',
+                        'mailbox://nobody@Local%20Folders/Drafts']);
     }
 
-    // Set check_new_mail to false. We can't do this through the account setup, so let's do it here.
-    var checkNewMail = 'mail.server.%serverkey%.check_new_mail';
-    var checkNewMailPref = checkNewMail.replace("%serverkey%", serverkey);
-    prefs.setBoolPref(checkNewMailPref, false);
-
-    // Do not check for new messages at startup.
-    var loginAtStartup = 'mail.server.%serverkey%.login_at_startup';
-    var loginAtStartupPref = loginAtStartup.replace("%serverkey%", serverkey);
-    prefs.setBoolPref(loginAtStartupPref, false);
-
-    // Do not automatically download new messages.
+    // Do not automatically download new messages in POP accounts.
     if (protocol === "pop3") {
-      var downloadOnBiff = 'mail.server.%serverkey%.download_on_biff';
-      var downloadOnBiffPref = downloadOnBiff.replace("%serverkey%", serverkey);
-      prefs.setBoolPref(downloadOnBiffPref, false);
+        pref_spec.push(['mail.server.%serverkey%.download_on_biff', false]);
+    }
+
+    for each (var [pref_template, value] in pref_spec) {
+        var pref = pref_template.replace("%idkey%", idkey);
+        pref = pref.replace("%serverkey%", serverkey);
+        Preferences.set(pref, value);
     }
   }
 

--- a/chrome/content/emailwizard.xul
+++ b/chrome/content/emailwizard.xul
@@ -9,7 +9,7 @@
   </stringbundleset>
 
   <button id="next_button"
-      oncommand="org.torbirdy.emailwizard.disableAutoWizard();" />
+      oncommand="org.torbirdy.emailwizard.adjustAutoWizard();" />
 
   <vbox id="mastervbox" flex="1">
     <groupbox id="torbirdy-protocol-box" class="indent" insertafter="initialSettings">

--- a/chrome/content/preferences.js
+++ b/chrome/content/preferences.js
@@ -41,7 +41,7 @@ if (!org.torbirdy.prefs) org.torbirdy.prefs = new function() {
     if (pub.prefs.getBoolPref("extensions.torbirdy.enigmail.throwkeyid")) {
       opts += "--throw-keyids ";
     }
-    var proxy = "http-proxy=http://127.0.0.1:8118";
+    var proxy = "socks5h://127.0.0.1:9050";
     if (anonService === "jondo") {
       proxy = "http://127.0.0.1:4001";
     }

--- a/chrome/content/preferences.js
+++ b/chrome/content/preferences.js
@@ -37,36 +37,20 @@ if (!org.torbirdy.prefs) org.torbirdy.prefs = new function() {
   };
 
   pub.setEnigmailPrefs = function(anonService) {
+    var opts = "";
     if (pub.prefs.getBoolPref("extensions.torbirdy.enigmail.throwkeyid")) {
-      if (anonService === "tor") {
-        return "--no-emit-version " +
-               "--no-comments " +
-               "--throw-keyids " +
-               "--display-charset utf-8 " +
-               "--keyserver-options no-auto-key-retrieve,no-try-dns-srv,http-proxy=http://127.0.0.1:8118";
-      }
-      if (anonService === "jondo") {
-        return "--no-emit-version " +
-               "--no-comments " +
-               "--throw-keyids " +
-               "--display-charset utf-8 " +
-               "--keyserver-options no-auto-key-retrieve,no-try-dns-srv,http-proxy=http://127.0.0.1:4001";
-      }
+      opts += "--throw-keyids ";
     }
-    else {
-      if (anonService === "tor") {
-        return "--no-emit-version " +
-               "--no-comments " +
-               "--display-charset utf-8 " +
-               "--keyserver-options no-auto-key-retrieve,no-try-dns-srv,http-proxy=http://127.0.0.1:8118";
-      }
-      if (anonService === "jondo") {
-        return "--no-emit-version " +
-               "--no-comments " +
-               "--display-charset utf-8 " +
-               "--keyserver-options no-auto-key-retrieve,no-try-dns-srv,http-proxy=http://127.0.0.1:4001";
-      }
+    var proxy = "http-proxy=http://127.0.0.1:8118";
+    if (anonService === "jondo") {
+      proxy = "http://127.0.0.1:4001";
     }
+    return opts +
+           "--no-emit-version " +
+           "--no-comments " +
+           "--display-charset utf-8 " +
+           "--keyserver-options no-auto-key-retrieve,no-try-dns-srv,http-proxy=" +
+           proxy;
   };
 
   pub.updateKeyserver = function(anonService) {

--- a/components/torbirdy.js
+++ b/components/torbirdy.js
@@ -181,6 +181,14 @@ const TorBirdyPrefs = {
   "mail.inline_attachments": false,
   // Do not IDLE (disable push mail).
   "mail.server.default.use_idle": false,
+  // Thunderbird's autoconfig wizard is designed to enable an initial
+  // mail fetch (by setting login_at_start) for the first account it
+  // creates (which will become the "default" account, see
+  // msgMail3PaneWindow.js for details) which side-steps the settings
+  // we apply in fixupTorbirdySettingsOnNewAccount(). Hence, fool
+  // Thunderbird to think that this initial mail fetch has already
+  // been done so we get the settings we want.
+  "mail.startup.enabledMailCheckOnce": true,
 
   /*
     Browser

--- a/components/torbirdy.js
+++ b/components/torbirdy.js
@@ -223,7 +223,7 @@ const TorBirdyPrefs = {
                                               // We want to force UTF-8 everywhere
                                               "--display-charset utf-8 " +
                                               // We want to ensure that Enigmail is proxy aware even when it runs gpg in a shell
-                                              "--keyserver-options http-proxy=http://127.0.0.1:8118 ",
+                                              "--keyserver-options http-proxy=socks5h://127.0.0.1:9050 ",
                                             
   // The default key server should be a hidden service and this is the only known one (it's part of the normal SKS network)
   "extensions.enigmail.keyserver": "hkp://qdigse2yzvuglcix.onion",


### PR DESCRIPTION
Hi,

Torbirdy disables Thunderbird's autoconfig wizard by default, and in order not to lose Torbirdy's secure options, we made some changes for Tails to be able to use the wizard, while still proposing only secure options (this is currently being upstreamed at https://bugzilla.mozilla.org/show_bug.cgi?id=669238 and available in Tails from our own packages).

What these patches do:
* **Use Tor's SOCKSPort for Enigmail's keyserver configuration.** It's not necessarily the case that users have an HTTP proxy running on port 8118, and if they do it may be a non-torified Privoxy instance. Using the Tor SOCKSPort will always work, and be torified.
* **Always disable remote account creation.** When the automatic configuration wizard is enabled we probably want to use *it*, and not the remote account creation feature. If that is something TorBirdys want to make enabled as an option, it should not be baked into this same pref. However, it probably is something TorBirdy should not encourage (at least we in Tails decided to disable it), so always hiding it seems like a good idea. This fixes Tails bug https://labs.riseup.net/code/issues/10464
*  **Do not check for new messages at startup.**

We have created ISO images which implement these changes in Tails if ever you wish to test them yourself. These images can be found here: http://nightly.tails.boum.org/build_Tails_ISO_feature-6154-secure-autoconfig-in-icedove/builds/lastSuccessfulBuild/archive/build-artifacts/

Please let me know if this suits you.

Cheers!
u.